### PR TITLE
Refactor build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+binaries/
 
 # Folders
 _obj

--- a/build.sh
+++ b/build.sh
@@ -21,4 +21,5 @@ for os in darwin freebsd openbsd linux windows; do
 		build "$os" "$arch"
 	done
 done
+
 build linux arm

--- a/build.sh
+++ b/build.sh
@@ -1,27 +1,24 @@
 #!/bin/bash
 
-version="$1"
-mkdir -p "binairies/""$version"
-name="binairies/""$version""/linx-client-v""$version""_"
+if [ -n "$1" ]; then
+	version="$1"
+else
+	version=$(git tag | grep ^v | tail -1 | sed 's/^v//')
+fi
 
-GOOS=darwin GOARCH=amd64 go build -o "$name"osx-amd64
+echo "Building version ${version}..."
 
-GOOS=darwin GOARCH=386 go build -o "$name"osx-386
+mkdir -p "binairies/$version"
 
-GOOS=freebsd GOARCH=amd64 go build -o "$name"freebsd-amd64
+build() {
+	echo "Building for $1-${2}..."
+	env GOOS="$1" GOARCH="$2" go build \
+	  -o "binairies/$version/linx-client-v${version}_$1-$2"
+}
 
-GOOS=freebsd GOARCH=386 go build -o "$name"freebsd-386
-
-GOOS=openbsd GOARCH=amd64 go build -o "$name"openbsd-amd64
-
-GOOS=openbsd GOARCH=386 go build -o "$name"bsd-386
-
-GOOS=linux GOARCH=arm go build -o "$name"linux-arm
-
-GOOS=linux GOARCH=amd64 go build -o "$name"linux-amd64
-
-GOOS=linux GOARCH=386 go build -o "$name"linux-386
-
-GOOS=windows GOARCH=amd64 go build -o "$name"windows-amd64.exe
-
-GOOS=windows GOARCH=386 go build -o "$name"windows-386.exe
+for os in darwin freebsd openbsd linux windows; do
+	for arch in amd64 386; do
+		build "$os" "$arch"
+	done
+done
+build linux arm

--- a/build.sh
+++ b/build.sh
@@ -8,12 +8,13 @@ fi
 
 echo "Building version ${version}..."
 
-mkdir -p "binairies/$version"
+bin_dir="binaries/$version"
+mkdir -p "$bin_dir"
 
 build() {
 	echo "Building for $1-${2}..."
 	env GOOS="$1" GOARCH="$2" go build \
-	  -o "binairies/$version/linx-client-v${version}_$1-$2"
+	  -o "binaries/$version/linx-client-v${version}_$1-$2"
 }
 
 for os in darwin freebsd openbsd linux windows; do


### PR DESCRIPTION
I still question bash scripts as build infrastructure, but at least it's DRY.

Also, use default version string from last git tag instead of requiring one one as (undocumented and un-checked) arg.
