### PR TITLE
Added a flag for outputing/clipboarding the selif link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+binaries
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 version="$1"
-mkdir -p "binairies/""$version"
-name="binairies/""$version""/linx-client-v""$version""_"
+mkdir -p "binaries/""$version"
+name="binaries/""$version""/linx-client-v""$version""_"
 
 GOOS=darwin GOARCH=amd64 go build -o "$name"osx-amd64
 

--- a/linx.go
+++ b/linx.go
@@ -56,6 +56,7 @@ func main() {
 	var desiredFileName string
 	var configPath string
 	var noClipboard bool
+	var useSelifURL bool
 	var useShortURL bool
 
 	flag.BoolVar(&del, "d", false,
@@ -74,6 +75,8 @@ func main() {
 		"Overwrite file (assuming you have its delete key")
 	flag.BoolVar(&noClipboard, "no-cb", false,
 		"Disable automatic insertion into clipboard")
+	flag.BoolVar(&useSelifURL, "selif", false,
+		"Return selif url")
 	flag.BoolVar(&useShortURL, "s", false,
 		"Fetch shorted url")
 	flag.Parse()
@@ -87,12 +90,12 @@ func main() {
 		}
 	} else {
 		for _, fileName := range flag.Args() {
-			upload(fileName, deleteKey, randomize, expiry, overwrite, desiredFileName, noClipboard, useShortURL)
+			upload(fileName, deleteKey, randomize, expiry, overwrite, desiredFileName, noClipboard, useSelifURL, useShortURL)
 		}
 	}
 }
 
-func upload(filePath string, deleteKey string, randomize bool, expiry int64, overwrite bool, desiredFileName string, noClipboard bool, useShortURL bool) {
+func upload(filePath string, deleteKey string, randomize bool, expiry int64, overwrite bool, desiredFileName string, noClipboard bool, useSelifURL bool, useShortURL bool) {
 	var reader io.Reader
 	var fileName string
 	var ssum string
@@ -177,6 +180,16 @@ func upload(filePath string, deleteKey string, randomize bool, expiry int64, ove
 		}
 
 		finalURL := myResp.Url
+
+		if useSelifURL {
+			length := len(strings.Split(myResp.Url, "/")) + 1
+			slice := make([]string, length)
+			copy(slice, strings.Split(myResp.Url, "/"))
+
+			copy(slice[length - 1:], slice[length - 2:])
+			copy(slice[length - 2:], []string{"selif"})
+			finalURL = strings.Join(slice, "/")
+		}
 
 		if useShortURL {
 			shortenedURL, err := getShortURL(myResp.Url + "/short")


### PR DESCRIPTION
Hey @andreimarcu,
This is my first time doing anything with Go in general, so let me know if there's something not right about the code.

The thing I added as a switch called `-selif` where the program now clipboard or shows the link but with the `selif` link. I needed this to send hotlinked images to Slack :D