### PR TITLE
use sha256-simd

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
-
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/minio/sha256-simd"
 )
 
 func checkErr(err error) {


### PR DESCRIPTION
the SIMD sha256 implementation is much faster than the stdlib sha256 on modern CPUs, see https://github.com/minio/sha256-simd/#performance for details or run sha256-simd benchmarks yourself