### PR TITLE
Adjust build config for ARM architectures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,9 @@ GOOS=openbsd GOARCH=amd64 go build -o "$name"openbsd-amd64
 
 GOOS=openbsd GOARCH=386 go build -o "$name"bsd-386
 
-GOOS=linux GOARCH=arm go build -o "$name"linux-arm
+GOOS=linux GOARCH=arm GOARM=7 go build -o "$name"linux-armv7
+
+GOOS=linux GOARCH=arm64 go build -o "$name"linux-arm64
 
 GOOS=linux GOARCH=amd64 go build -o "$name"linux-amd64
 


### PR DESCRIPTION
This PR adds a build target for the ARMv8 architecture and ensures the existing ARM build is explicitly targeted at v7. The latter change is the recommended setup in cross compilation situations according to https://github.com/golang/go/wiki/GoArm.