### PR TITLE
Feature: Read API key via pass command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Configuring linx-client
 
 Site url (ex: https://linx.example.com/): https://linx.example.com/
 Logfile path (ex: ~/.linxlog): ~/.linxlog
-API key retreival command (ex 'pass show linx-client', leave blank if instance is public): pass show linx-client
+API key retreival command (leave blank if instance is public, ex: pass show linx-client): pass show linx-client
 Configuration written at /home/kalle/.config/linx-client.conf
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,51 @@ API key retreival command (leave blank for plain token or if instance is public,
 Configuration written at /home/kalle/.config/linx-client.conf
 ```
 
+
+### Loading API key from external application
+
+Your API key can either be stored directly in plain text in your
+`~/.config/linx-client.conf` file, such as:
+
+```json
+{
+    "apikey": "your-api-key-here",
+    "logfile": "/home/you/.linxlog",
+    "siteurl": "https://linx.example.com/"
+}
+```
+
+Or you can use an external tool, such as [pass](https://www.passwordstore.org/)
+to store it encrypted.
+
+If you specify the config key `apikeycmd`, it will take precedence over the
+`apikey` config key, and execute it when it needs the token.
+
+```json
+{
+    "apikey": "",
+    "apikeycmd": "pass show linx-client",
+    "logfile": "/home/you/.linxlog",
+    "siteurl": "https://linx.example.com/"
+}
+```
+
+The `apikeycmd` config key does support quoting. Specifying
+`pass show 'my key'` will resolve in running command `pass` with the 2
+arguments, `show`, and `my key`. Whereas `pass show my key` would resolve as
+the command `pass` and the 3 arguments `show`, `my`, and `key`. Different
+programs handle argument grouping differently. But for [pass](https://www.passwordstore.org/)
+in particular the latter would be an invalid command as it only expects 1 pass
+key name.
+
+
+### Without API key (public instance)
+
+By leaving both `apikey` and `apikeycmd` empty, linx-client will assume the
+target instance is publicly writable and will then perform its requests without
+any API key.
+
+
 Usage
 ----- 
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ arguments, `show`, and `my key`. Whereas `pass show my key` would resolve as
 the command `pass` and the 3 arguments `show`, `my`, and `key`. Different
 programs handle argument grouping differently. But for [pass](https://www.passwordstore.org/)
 in particular the latter would be an invalid command as it only expects 1 pass
-key name.
+name.
 
 
 ### Without API key (public instance)
 
 By leaving both `apikey` and `apikeycmd` empty, linx-client will assume the
 target instance is publicly writable and will then perform its requests without
-any API key.
+an API key.
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ Configuration
 When you first run linx-client, you will be prompted to configure the instance url, logfile path and api keys. 
 
 ```
-$ ./linx-client  
-Configuring linx-client  
-  
-Site url (ex: https://linx.example.com/): https://linx.example.com/  
-Logfile path (ex: ~/.linxlog): ~/.linxlog  
-API key (leave blank if instance is public):  
-  
-Configuration written at ~/.config/linx-client.conf  
+$ ./linx-client
+Configuring linx-client
+
+Site url (ex: https://linx.example.com/): https://linx.example.com/
+Logfile path (ex: ~/.linxlog): ~/.linxlog
+API key retreival command (ex 'pass show linx-client', leave blank if instance is public): pass show linx-client
+Configuration written at /home/kalle/.config/linx-client.conf
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Configuration written at /home/kalle/.config/linx-client.conf
 ```
 
 
-### Loading API key from external application
+### With API key
 
 Your API key can either be stored directly in plain text in your
 `~/.config/linx-client.conf` file, such as:
@@ -50,10 +50,11 @@ Your API key can either be stored directly in plain text in your
 ```
 
 Or you can use an external tool, such as [pass](https://www.passwordstore.org/)
-to store it encrypted.
+to store it as encrypted.
 
 If you specify the config key `apikeycmd`, it will take precedence over the
-`apikey` config key, and execute it when it needs the token.
+`apikey` config key, and will run and use the first line of output from that
+command when it performs any request.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Configuring linx-client
 Site url (ex: https://linx.example.com/): https://linx.example.com/
 Logfile path (ex: ~/.linxlog): ~/.linxlog
 API key retreival command (leave blank for plain token or if instance is public, ex: pass show linx-client): pass show 'linx-client'
-Configuration written at /home/kalle/.config/linx-client.conf
+Configuration written at ~/.config/linx-client.conf
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Configuring linx-client
 
 Site url (ex: https://linx.example.com/): https://linx.example.com/
 Logfile path (ex: ~/.linxlog): ~/.linxlog
-API key retreival command (leave blank if instance is public, ex: pass show linx-client): pass show linx-client
+API key retreival command (leave blank for plain token or if instance is public, ex: pass show linx-client): pass show 'linx-client'
 Configuration written at /home/kalle/.config/linx-client.conf
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/atotto/clipboard v0.1.2
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mutantmonkey/golinx v0.0.0-20190822073349-04d0ad80761f
 	github.com/timshannon/config v0.0.0-20161208040744-63089074048e

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/adrg/xdg v0.0.0-20190319220657-88e5137d2444/go.mod h1:ZuOshBmzV4Ta+s2
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=

--- a/linx.go
+++ b/linx.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -250,10 +249,14 @@ func getApiKey() string {
 		return ""
 	}
 
-	out, err := exec.Command(Config.apikeycmd).Output()
+	apikey, err := runCmdFirstLine(Config.apikeycmd)
 	checkErr(err)
 
-	return string(out)
+	if apikey == "" {
+		checkErr(fmt.Errorf("Command did not produce an API key: %s", Config.apikeycmd))
+	}
+
+	return apikey
 }
 
 func addKey(url string, deleteKey string) {

--- a/linx.go
+++ b/linx.go
@@ -327,12 +327,12 @@ func parseConfig(configPath string) {
 		cfg.SetValue("logfile", Config.logfile)
 
 		if Config.apikeycmd == "" && Config.apikey == "" {
-			Config.apikeycmd = getInput("API key retreival command (ex 'pass show linx-client', leave blank if instance is public)", true)
+			Config.apikeycmd = getInput("API key retreival command (leave blank if instance is public, ex: pass show linx-client)", true)
 		}
 		cfg.SetValue("apikeycmd", Config.apikeycmd)
 
 		if Config.apikey == "" && Config.apikeycmd == "" {
-			Config.apikey = getInput("API key (will be stored in plain text, leave blank if instance is public)", true)
+			Config.apikey = getInput("API key (leave blank if instance is public, will be stored in plain text)", true)
 		}
 		cfg.SetValue("apikey", Config.apikey)
 

--- a/linx.go
+++ b/linx.go
@@ -327,7 +327,7 @@ func parseConfig(configPath string) {
 		cfg.SetValue("logfile", Config.logfile)
 
 		if Config.apikeycmd == "" && Config.apikey == "" {
-			Config.apikey = getInput("API key retreival command (ex 'pass show linx-client', leave blank if instance is public)", true)
+			Config.apikeycmd = getInput("API key retreival command (ex 'pass show linx-client', leave blank if instance is public)", true)
 		}
 		cfg.SetValue("apikeycmd", Config.apikeycmd)
 

--- a/linx.go
+++ b/linx.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -138,8 +139,8 @@ func upload(filePath string, deleteKey string, accessKey string, randomize bool,
 	req.Header.Set("User-Agent", "linx-client")
 	req.Header.Set("Accept", "application/json")
 
-	if Config.apikey != "" {
-		req.Header.Set("Linx-Api-Key", Config.apikey)
+	if apikey := getApiKey(); apikey != "" {
+		req.Header.Set("Linx-Api-Key", apikey)
 	}
 	if deleteKey != "" {
 		req.Header.Set("Linx-Delete-Key", deleteKey)
@@ -222,8 +223,8 @@ func deleteUrl(url string) {
 	req.Header.Set("User-Agent", "linx-client")
 	req.Header.Set("Linx-Delete-Key", deleteKey)
 
-	if Config.apikey != "" {
-		req.Header.Set("Linx-Api-Key", Config.apikey)
+	if apikey := getApiKey(); apikey != "" {
+		req.Header.Set("Linx-Api-Key", apikey)
 	}
 
 	client := &http.Client{}
@@ -238,6 +239,21 @@ func deleteUrl(url string) {
 		checkErr(errors.New("Could not delete " + url))
 	}
 
+}
+
+func getApiKey() string {
+	if Config.apikey != "" {
+		return Config.apikey
+	}
+
+	if Config.apikeycmd == "" {
+		return ""
+	}
+
+	out, err := exec.Command(Config.apikeycmd).Output()
+	checkErr(err)
+
+	return string(out)
 }
 
 func addKey(url string, deleteKey string) {

--- a/linx.go
+++ b/linx.go
@@ -330,7 +330,21 @@ func parseConfig(configPath string) {
 		cfg.SetValue("logfile", Config.logfile)
 
 		if Config.apikeycmd == "" && Config.apikey == "" {
-			Config.apikeycmd = getInput("API key retreival command (leave blank if instance is public, ex: pass show linx-client)", true)
+			for {
+				Config.apikeycmd = getInput("API key retreival command (leave blank for plain token or if instance is public, ex: pass show linx-client)", true)
+
+				if Config.apikeycmd == "" {
+					break
+				}
+
+				err := validateCommand(Config.apikeycmd)
+
+				if err != nil {
+					fmt.Printf("Invalid API key retreival command: %v\n", err)
+				} else {
+					break
+				}
+			}
 		}
 		cfg.SetValue("apikeycmd", Config.apikeycmd)
 

--- a/linx.go
+++ b/linx.go
@@ -98,6 +98,10 @@ func upload(filePath string, deleteKey string, accessKey string, randomize bool,
 	var fileName string
 	var ssum string
 
+	// Need to fetch this before we setup the progress reader
+	// as it can conflict with the apikeycmd output
+	apikey := getApiKey()
+
 	if filePath == "-" {
 		byt, err := ioutil.ReadAll(os.Stdin)
 		checkErr(err)
@@ -138,7 +142,7 @@ func upload(filePath string, deleteKey string, accessKey string, randomize bool,
 	req.Header.Set("User-Agent", "linx-client")
 	req.Header.Set("Accept", "application/json")
 
-	if apikey := getApiKey(); apikey != "" {
+	if apikey != "" {
 		req.Header.Set("Linx-Api-Key", apikey)
 	}
 	if deleteKey != "" {
@@ -250,7 +254,10 @@ func getApiKey() string {
 	}
 
 	apikey, err := runCmdFirstLine(Config.apikeycmd)
-	checkErr(err)
+
+	if err != nil {
+		checkErr(fmt.Errorf("Failed to retrieve API key: %w", err))
+	}
 
 	if apikey == "" {
 		checkErr(fmt.Errorf("Command did not produce an API key: %s", Config.apikeycmd))

--- a/linx.go
+++ b/linx.go
@@ -17,9 +17,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/timshannon/config"
 	"github.com/atotto/clipboard"
 	"github.com/mutantmonkey/golinx/progress"
+	"github.com/timshannon/config"
 )
 
 type RespOkJSON struct {
@@ -37,9 +37,10 @@ type RespErrJSON struct {
 }
 
 var Config struct {
-	siteurl string
-	logfile string
-	apikey  string
+	siteurl   string
+	logfile   string
+	apikey    string
+	apikeycmd string
 }
 
 var keys map[string]string
@@ -282,6 +283,7 @@ func parseConfig(configPath string) {
 	Config.siteurl = cfg.String("siteurl", "")
 	Config.logfile = cfg.String("logfile", "")
 	Config.apikey = cfg.String("apikey", "")
+	Config.apikeycmd = cfg.String("apikeycmd", "")
 
 	if Config.siteurl == "" || Config.logfile == "" {
 		fmt.Println("Configuring linx-client")
@@ -308,8 +310,13 @@ func parseConfig(configPath string) {
 		}
 		cfg.SetValue("logfile", Config.logfile)
 
-		if Config.apikey == "" {
-			Config.apikey = getInput("API key (leave blank if instance is public)", true)
+		if Config.apikeycmd == "" && Config.apikey == "" {
+			Config.apikey = getInput("API key retreival command (ex 'pass show linx-client', leave blank if instance is public)", true)
+		}
+		cfg.SetValue("apikeycmd", Config.apikeycmd)
+
+		if Config.apikey == "" && Config.apikeycmd == "" {
+			Config.apikey = getInput("API key (will be stored in plain text, leave blank if instance is public)", true)
 		}
 		cfg.SetValue("apikey", Config.apikey)
 

--- a/util.go
+++ b/util.go
@@ -82,6 +82,7 @@ func runCmdFirstLine(cmdAndArgs string) (string, error) {
 	scanner := bufio.NewReader(stdout)
 
 	line, err := scanner.ReadString('\n')
+	line = strings.TrimRight(line, "\n")
 
 	if err := cmd.Wait(); err != nil {
 		return line, err

--- a/util.go
+++ b/util.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/minio/sha256-simd"
 )
@@ -17,9 +19,12 @@ func checkErr(err error) {
 }
 
 func getInput(query string, allowBlank bool) (input string) {
+	scanner := bufio.NewScanner(os.Stdin)
+
 	for input == "" {
 		fmt.Print(query + ": ")
-		fmt.Scanf("%s\n", &input)
+		scanner.Scan()
+		input = strings.TrimSpace(scanner.Text())
 
 		if allowBlank {
 			break


### PR DESCRIPTION
- Added loading of apikeycmd
- Added getApiKey to get from apikeycmd
- Updated README.md
- Changed getInput to use bufio.Scanner instead so it handles multiple words
- Added <https://github.com/kballard/go-shellquote>
- Added splitting of arguments, and validating when configuring

## Preview

![linx-client-apikeycmd](https://user-images.githubusercontent.com/2477952/104110644-fcf18680-52d9-11eb-9feb-b73b7928ba2c.gif)

```sh
$ cat ~/.config/linx-client.conf
{
    "apikey": "",
    "apikeycmd": "pass show 'web/files.jilleJr.tech'",
    "logfile": "/home/kalle/.linxlog",
    "siteurl": "https://files.jillejr.tech/"
}
```

---

Closes #21 